### PR TITLE
Add page fade transitions and prefetching for internal links

### DIFF
--- a/css/phase3.css
+++ b/css/phase3.css
@@ -295,3 +295,16 @@ main.container { flex: 1 0 auto; }
 .my-1 { margin-top: 8px !important; margin-bottom: 8px !important; }
 .my-2 { margin-top: 16px !important; margin-bottom: 16px !important; }
 .my-3 { margin-top: 24px !important; margin-bottom: 24px !important; }
+
+/* --------------------------------------------------
+   Page fade transitions (global, low-risk)
+   - Works across full navigations using small CSS + JS hooks
+   - Respects reduced motion preference
+  -------------------------------------------------- */
+body { transition: opacity .24s ease; }
+body.pt-enter { opacity: 0; }
+body.pt-enter-active { opacity: 1; }
+body.pt-exit { opacity: 0; }
+@media (prefers-reduced-motion: reduce) {
+  body { transition: none !important; }
+}


### PR DESCRIPTION
- Implemented CSS transitions for page fade effects on navigation.
- Enhanced JavaScript to handle enter/exit animations and respect reduced motion preferences.
- Added prefetching for internal links on mouseover to improve navigation performance.
- Intercepted clicks on internal links to trigger exit fade before navigation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added smooth fade transitions when navigating between pages.
  * Implemented intelligent link prefetching to improve navigation performance.
  * Transitions respect user accessibility preferences for reduced motion.
  * Handles various navigation types including back/forward browser actions for consistent visual feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->